### PR TITLE
Redundant code

### DIFF
--- a/src/contracts/rps.py
+++ b/src/contracts/rps.py
@@ -26,17 +26,13 @@ Draws = Bytes('Draw')
 @Subroutine(TealType.none)
 def reset_round(account1 : Expr, account2 : Expr):
     return Seq(App.localPut(account1 ,local_play , Bytes("")),
-                App.localPut(account1 , local_play , Bytes("")),
                 App.localPut(account2 ,local_play , Bytes("")),
-                App.localPut(account2 , local_play , Bytes("")),
                 App.globalPut(round , App.globalGet(round ) - Int(1)),
     )
 
 @Subroutine(TealType.none)
 def reset_all(account1 : Expr, account2 : Expr):
     return Seq(App.localPut(account1 , local_play , Bytes("")),
-                App.localPut(account1 , local_play , Bytes("")),
-                App.localPut(account2 , local_play , Bytes("")),
                 App.localPut(account2 , local_play , Bytes("")),
                 App.globalPut(round , Int(0)),
                 App.globalPut(wager , Int(0)),


### PR DESCRIPTION
👩‍💻 Hello [hilary3211](https://github.com/hilary3211)
# Remove Redundancy

-  There is a **redundant** code in your `reset-round` subroutine and also in your `reset_all`, They both use `localPut` twice to set `local_play` to an empty string when one `localPut` can do it 